### PR TITLE
Check for single quotes on import statements

### DIFF
--- a/sass2scss.cpp
+++ b/sass2scss.cpp
@@ -569,7 +569,7 @@ namespace Sass
 				size_t pos_import = sass.find_first_of(" \t\n\v\f\r", pos_left + 7);
 				size_t pos_quote = sass.find_first_not_of(" \t\n\v\f\r", pos_import);
 				// check if the url is quoted
-				if (sass.substr(pos_quote, 1) != "\"")
+				if (sass.substr(pos_quote, 1) != "\"" && sass.substr(pos_quote, 1) != "\'")
 				{
 					// get position of the last char on the line
 					size_t pos_end = sass.find_last_not_of(" \t\n\v\f\r");


### PR DESCRIPTION
When checking if the `@import` argument url is quoted, it [currently only checks for double quotes.](https://github.com/mgreter/sass2scss/blob/a35b799f49d7d335ddc2b765b13d7d5db1d1247f/sass2scss.cpp#L572). I'm not sure if this is part of the official spec but libsass supports single quotes for imports in scss files.

So before when compiling this:

``` sass
@import 'bourbon'

div
  @include border-radius(10px)
```

It resolved to something like this:

``` scss
@import "'bourbon'";
div { @include border-radius(10px) }
```

`bourbon` ended up surrounded by both single and double quotes.

I just changed the check to also look for single quotes when determining if the import argument is quoted.
