### PR TITLE
Produce valid output for @include

### DIFF
--- a/sass2scss.cpp
+++ b/sass2scss.cpp
@@ -607,6 +607,7 @@ namespace Sass
 			else if (
 				sass.substr(pos_left, 7) != "@return" &&
 				sass.substr(pos_left, 7) != "@extend" &&
+				sass.substr(pos_left, 8) != "@include" &&
 				sass.substr(pos_left, 8) != "@content"
 			) {
 


### PR DESCRIPTION
```
@include foo
```
Currently produces
```
@include () {}
```
Which is not valid sass and produces the following error
```
Error: Mixin "foo" does not accept a content block.
```
This patch changes the output
```
@include foo();
```
Originally patched in LibSass - https://github.com/sass/libsass/pull/1547