### PR TITLE
Add support to multiline declarations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ all: sass2scss
 CXXFLAGS = -DSASS2SCSS_VERSION="\"$(SASS2SCSS_VERSION)\""
 
 sass2scss.o: sass2scss.cpp
-	g++ $(CXXFLAGS) -Wall -c sass2scss.cpp
+	g++ -std=c++0x $(CXXFLAGS) -Wall -c sass2scss.cpp
 
 sass2scss: sass2scss.o
-	g++ $(CXXFLAGS) -Wall -o sass2scss -I. tool/sass2scss.cpp sass2scss.o
+	g++ -std=c++0x $(CXXFLAGS) -Wall -o sass2scss -I. tool/sass2scss.cpp sass2scss.o
 
 clean:
 	ifeq ($(OS),Windows_NT)

--- a/sass2scss.cpp
+++ b/sass2scss.cpp
@@ -39,9 +39,9 @@ namespace Sass
 {
 
 	// Regexes used to preprocess the sass file
-	std::regex space_regex("[[:space:]]*");
-	std::regex line_break_regex(".*[\\\\:,][[:space:]]*");
-	std::regex backslash_regex(".*[\\][[:space:]]*");
+	std::regex space_regex("\\s*");
+	std::regex line_break_regex(".*[\\\\:,]\\s*");
+	std::regex backslash_regex(".*\\\\s*");
 
 	// return the actual prettify value from options
 	#define PRETTIFY(converter) (converter.options - (converter.options & 248))

--- a/test/test.sass
+++ b/test/test.sass
@@ -14,6 +14,9 @@
 #main
   color: blue
   font-size: 0.3em
+  font-family: Arial \
+    , "Lucida Sans" \
+    , sans-serif;
 
   a
     font:

--- a/test/test.sass
+++ b/test/test.sass
@@ -35,13 +35,13 @@ body
   // a
   color: black
    // This comment is indented, so this
-    will actually open a new block scope
+   // will actually open a new block scope
   color: red
 a
   color: green
   // This comment will not appear in the CSS output.
   // This is nested beneath the comment as well,
-     so it also won't appear
+  // so it also won't appear
 
 =large-text
   font:
@@ -49,6 +49,8 @@ a
     size: 20px
     weight: bold
   color: #ff0000
+  transition: opacity 0.2s ease,
+    color 0.2s ease
 
 h1
   +large-text


### PR DESCRIPTION
This change adds support to multiline declarations in indented syntax.

If the declaration ends with a backslash, comma, colon, or doesn't have balanced parenthesis, then the subsequent line is concatenated to form one single instruction.