### PR TITLE
Improve makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,21 +20,30 @@ else
 	SUFFIX ?=
 endif
 
+$(CXX) ?= g++
+
 all: sass2scss
 
 CXXFLAGS = -DSASS2SCSS_VERSION="\"$(SASS2SCSS_VERSION)\""
 
 sass2scss.o: sass2scss.cpp
-	g++ $(CXXFLAGS) -Wall -c sass2scss.cpp
+	$(CXX) $(CXXFLAGS) -Wall -c sass2scss.cpp
 
-sass2scss: sass2scss.o
-	g++ $(CXXFLAGS) -Wall -o sass2scss -I. tool/sass2scss.cpp sass2scss.o
+sass2scss: tool/sass2scss.cpp sass2scss.o
+	$(CXX) $(CXXFLAGS) -Wall -o sass2scss -I. $^
 
 clean:
-	ifeq ($(OS),Windows_NT)
-		${RM} sass2scss.o 2>NUL
-		${RM} sass2scss.exe 2>NUL
-	else
-		${RM} sass2scss.o
-		${RM} sass2scss
-	endif
+ifeq ($(OS),Windows_NT)
+	${RM} sass2scss.o 2>NUL
+	${RM} sass2scss.exe 2>NUL
+else
+	${RM} sass2scss.o
+	${RM} sass2scss
+endif
+
+options:
+	# compiler is $(CXX)
+	# flags are $(CXXFLAGS)
+	# version is $(SASS2SCSS_VERSION)
+
+.PHONY: all clean options

--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,10 @@ ifeq ($(OS),Windows_NT)
 	MV ?= move
 	CP ?= copy /Y
 	RM ?= del /Q /F
-	EXESUFFIX ?= .exe
-	SUFFIX ?= 2>NULL
 else
 	MV ?= mv -f
 	CP ?= cp -f
-	RM ?= rm -rf
-	EXESUFFIX ?=
-	SUFFIX ?=
+	RM ?= rm -f
 endif
 
 $(CXX) ?= g++
@@ -34,11 +30,11 @@ sass2scss: tool/sass2scss.cpp sass2scss.o
 
 clean:
 ifeq ($(OS),Windows_NT)
-	${RM} sass2scss.o 2>NUL
-	${RM} sass2scss.exe 2>NUL
+	$(RM) sass2scss.o 2>NUL
+	$(RM) sass2scss.exe 2>NUL
 else
-	${RM} sass2scss.o
-	${RM} sass2scss
+	$(RM) sass2scss.o
+	$(RM) sass2scss
 endif
 
 options:


### PR DESCRIPTION
- Use the right c++ compiler no matter what.
- Correct dependencies for sass2scss executable.
- Add options target to show what the options are.
- State phony options to reduce chance of bugs.
- Correct if statement in clean target.

----

The last one is especially important because it will error out otherwise.
Note: I didn't test this with windows nmake but it doesn't change much so I would expect it to still work.