### PR TITLE
Add "-std=c++98" to CXXFLAGS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ $(CXX) ?= g++
 
 all: sass2scss
 
-CXXFLAGS = -DSASS2SCSS_VERSION="\"$(SASS2SCSS_VERSION)\""
+CXXFLAGS = -std=c++98 -DSASS2SCSS_VERSION="\"$(SASS2SCSS_VERSION)\""
 
 sass2scss.o: sass2scss.cpp
 	$(CXX) $(CXXFLAGS) -Wall -c sass2scss.cpp


### PR DESCRIPTION
This flag disallows modern C++ features, so that we get the same behaviour compiling locally with a recent compiler as we do on CI with old compilers.