### PR TITLE
Fix bug that makes CXX not get set to g++.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ else
 	RM ?= rm -f
 endif
 
-$(CXX) ?= g++
+CXX ?= g++
 
 all: sass2scss
 


### PR DESCRIPTION
Putting `$()` around a variable causes it to get substituted. The assignment doesn't work if the variable on the left side is getting substituted. This patch fixes that.

In case you were curious, the Makefile should work on most systems even without this patch because they set `CXX` by default. That is why you haven't seen any complaints.